### PR TITLE
ci: enable `dependabot`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+    - package-ecosystem: "gomod"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build"
+          include: "scope"


### PR DESCRIPTION
`dependabot` would likely make it less likely that dependencies will be left outdated. This `dependabot` file is copied from https://github.com/nlnwa/go_container/blob/712d97712de12bdf76910f31cc5f9d177ff8acb0/.github/dependabot.yaml