### PR TITLE
ci: bump `golangci-lint` version

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.53
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
Version `1.29.0` currently fails with the, partially truncated, error message:

```
##[group]run golangci-lint
Running [/home/runner/golangci-lint-1.29.0-linux-amd64/golangci-lint run
--out-format=github-actions] in [] ...
level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir:
failed to load package goarch: could not load export data: cannot import \"internal/goarch\"
(unknown bexport format version -1 (...)), possibly version skew - reinstall package"
level=warning msg="[runner] Can't run linter unused: buildir: failed to
load package goarch: could not load export data: cannot import
\"internal/goarch\" (unknown bexport format version -1 (...)), possibly version skew - reinstall package"
level=error msg="Running error: buildir: failed to load package goarch:
could not load export data: cannot import \"internal/goarch\"
(unknown bexport format version -1 (...)), possibly version skew - reinstall package"
```

Updating to the latest version of `golangci-lint` seems to solve this issue.