### PR TITLE
ci: increase `golangci-lint` timeout

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -29,8 +29,7 @@ jobs:
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout=10m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
This commit increases the timeout from the default 60 seconds to 10 minutes. The reason for this change is that multiple workflows timed out with the following error:

```
##[group]run golangci-lint
Running [/home/runner/golangci-lint-1.53.3-linux-amd64/golangci-lint run
--out-format=github-actions] in [] ...
level=error msg="Running error: context loading failed: failed to load
packages: timed out to load packages: context deadline exceeded"
level=error msg="Timeout exceeded: try increasing it by passing
--timeout option"

##[error]golangci-lint exit with code 4
Ran golangci-lint in 61806ms
```