### PR TITLE
ci: use `golangci-lint` config file

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -29,7 +29,7 @@ jobs:
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
-          args: --timeout=10m
+          args: --timeout=10m --config=.golangci.yaml
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,122 @@
+output:
+  format: github-actions
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+linters-settings:
+  gofmt:
+    simplify: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  case-sensitive: true
+
+linters:
+  enable-all: true
+  disable:
+  # TODO(https://github.com/nlnwa/go_container/issues/3): The following
+  # sub-linters should be evaluated if they are going to be enabled or not.
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - cyclop
+    - deadcode
+    - decorder
+    - depguard
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exhaustivestruct
+    - exhaustruct
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosmopolitan
+    - grouper
+    - ifshort
+    - importas
+    - interfacebloat
+    - interfacer
+    - ireturn
+    - lll
+    - loggercheck
+    - maintidx
+    - makezero
+    - maligned
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosnakecase
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - structcheck
+    - stylecheck
+    - tagalign
+    - tagliatelle
+    - tenv
+    - testableexamples
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - varcheck
+    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
+    - zerologlint

--- a/server/sessioncontext.go
+++ b/server/sessioncontext.go
@@ -29,13 +29,13 @@ import (
 )
 
 type writeSessionContext struct {
-	configCache       database.ConfigCache
-	meta              *contentwriter.WriteRequestMeta
-	collectionConfig  *config.ConfigObject
-	recordOpts        []gowarc.WarcRecordOption
-	records           map[int32]gowarc.WarcRecord
-	recordBuilders    map[int32]gowarc.WarcRecordBuilder
-	rbMapSync         sync.Mutex
+	configCache      database.ConfigCache
+	meta             *contentwriter.WriteRequestMeta
+	collectionConfig *config.ConfigObject
+	recordOpts       []gowarc.WarcRecordOption
+	records          map[int32]gowarc.WarcRecord
+	recordBuilders   map[int32]gowarc.WarcRecordBuilder
+	rbMapSync        sync.Mutex
 }
 
 func newWriteSessionContext(configCache database.ConfigCache, recordOpts []gowarc.WarcRecordOption) *writeSessionContext {


### PR DESCRIPTION
This will standardize the sub-linters this repo uses with https://github.com/nlnwa/go_container/blob/007e57b813e912a55a3dbacb217c7b7d57034e6f/.github/workflows/main.yaml