### PR TITLE
ci: bump golangci-lint version

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.53
+          version: v1.56
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,7 @@ linters:
     - grouper
     - ifshort
     - importas
+    - inamedparam
     - interfacebloat
     - interfacer
     - ireturn
@@ -93,9 +94,11 @@ linters:
     - nosnakecase
     - nosprintfhostport
     - paralleltest
+    - perfsprint
     - prealloc
     - predeclared
     - promlinter
+    - protogetter
     - reassign
     - revive
     - rowserrcheck
@@ -107,6 +110,7 @@ linters:
     - tagliatelle
     - tenv
     - testableexamples
+    - testifylint
     - testpackage
     - thelper
     - tparallel


### PR DESCRIPTION
This commit bumps the golangci-lint version to
`1.56` from `1.53`.


Some linters needed to be disabled in order to
get this project working again. In follow up
commits some of these errors might get fixed.

Some of the relevant error messages:

```
lint: database/codec_test.go#L39
require-error: for error assertions use require (testifylint)
lint: database/codec_test.go#L70
avoid direct access to proto field expected.Date.AsTime(),
use expected.GetDate().AsTime() instead (protogetter)
lint: database/db.go#L132
fmt.Errorf can be replaced with errors.New (perfsprint)
lint: database/dbadapter.go#L33
interface method GetConfigObject must have named
param for type context.Context (inamedparam)
```